### PR TITLE
Support recursive types marshalling with lazy reflection

### DIFF
--- a/src/Fable.SimpleJson.fsproj
+++ b/src/Fable.SimpleJson.fsproj
@@ -7,7 +7,7 @@
     <PackageIconUrl></PackageIconUrl>
     <PackageTags>fsharp;fable;json;parser</PackageTags>
     <Authors>Zaid Ajaj</Authors>
-    <Version>2.0.0-beta-003</Version>
+    <Version>2.0.0-beta-004</Version>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>

--- a/src/TypeInfo.fs
+++ b/src/TypeInfo.fs
@@ -3,8 +3,19 @@ namespace Fable.SimpleJson
 open System
 open FSharp.Reflection
 
+type RecordField = {
+    FieldName: string 
+    FieldType: TypeInfo
+}
+
+and UnionCase = { 
+    CaseName: string 
+    CaseTypes: TypeInfo [ ] 
+    Info: UnionCaseInfo
+}
+
 /// A type that encodes type information which is easily serializable 
-type TypeInfo = 
+and TypeInfo = 
     | Unit 
     | String  
     | Int32 
@@ -15,14 +26,14 @@ type TypeInfo =
     | DateTime 
     | BigInt 
     | Guid 
-    | Object of Type
-    | Option of TypeInfo 
-    | List of TypeInfo 
-    | Set of TypeInfo 
-    | Array of TypeInfo
-    | Seq of TypeInfo 
-    | Tuple of TypeInfo [ ] 
-    | Map of key:TypeInfo * value:TypeInfo 
-    | Func of TypeInfo [ ] 
-    | Record of (string  * TypeInfo) [ ] * Type  
-    | Union of (string * UnionCaseInfo *  TypeInfo [ ]) [ ] * Type
+    | Object of (unit -> Type)
+    | Option of (unit -> TypeInfo) 
+    | List of (unit -> TypeInfo)  
+    | Set of (unit -> TypeInfo)  
+    | Array of (unit -> TypeInfo) 
+    | Seq of (unit -> TypeInfo)  
+    | Tuple of (unit -> TypeInfo [ ]) 
+    | Map of (unit -> TypeInfo * TypeInfo) 
+    | Func of (unit -> TypeInfo [ ]) 
+    | Record of (unit -> RecordField [ ] * Type)  
+    | Union of (unit -> UnionCase [ ] * Type)


### PR DESCRIPTION
```fs
type Recursive = {
    Name : string 
    Children : Recursive list
}

testCase "Recursive records can be converted" <| fun test ->
    let input = {
        Name = "root"
        Children = [ 
            { Name = "Child 1"; Children = [ { Name = "Grandchild 1"; Children = [ ] } ] }
            { Name = "Child 2"; Children = [ { Name = "Grandchild 2"; Children = [ ] } ] }
            { Name = "Child 2"; Children = [  ] }
        ]
    }

    input
    |> Json.stringify
    |> Json.parseAs<Recursive>
    |> test.areEqual input

type Tree = 
    | Leaf of int 
    | Branch of Tree * Tree 

testCase "Recursive unions can be converted" <| fun test ->
    let input = Branch(Branch(Leaf 10, Leaf 5), Leaf 5)
    
    input
    |> Json.stringify
    |> Json.parseAs<Tree>
    |> test.areEqual input
```