### PR TITLE
Fix #13 support unions within tuples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Fable.SimpleJson [![Build Status](https://travis-ci.org/Zaid-Ajaj/Fable.SimpleJson.svg?branch=master)](https://travis-ci.org/Zaid-Ajaj/Fable.SimpleJson)  [![Nuget](https://img.shields.io/nuget/v/Fable.SimpleJson.svg?maxAge=0&colorB=brightgreen)](https://www.nuget.org/packages/Fable.SimpleJson)
+# Fable.SimpleJson [![Build Status](https://travis-ci.org/Zaid-Ajaj/Fable.SimpleJson.svg?branch=master)](https://travis-ci.org/Zaid-Ajaj/Fable.SimpleJson) [![Build status](https://ci.appveyor.com/api/projects/status/i17usjpn7bbiwm9n?svg=true)](https://ci.appveyor.com/project/Zaid-Ajaj/fable-simplejson) [![Nuget](https://img.shields.io/nuget/v/Fable.SimpleJson.svg?maxAge=0&colorB=brightgreen)](https://www.nuget.org/packages/Fable.SimpleJson)
 
 A simple library for easily parsing, transforming and converting JSON in Fable projects. It is written using parser combinators from [Fable.Parsimmon](https://github.com/Zaid-Ajaj/Fable.Parsimmon)
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,10 +1,11 @@
 image: Ubuntu1804
 
+stack: node 10
+
 environment:
   nodejs_version: "10.10.0"
 
 build_script:
-- sh: ./install-node.sh
 - sh: ./build.sh RunTests
 
 test: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,7 @@ environment:
   nodejs_version: "10.10.0"
 
 build_script:
+- sh: ./install-node.sh
 - sh: ./build.sh RunTests
 
 test: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,9 @@
 image: Ubuntu1804
+
 environment:
-  - nodejs_version: 10.10.0
+  - nodejs_version: "10.10.0"
+
 build_script:
 - sh: ./build.sh RunTests
+
+test: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 image: Ubuntu1804
 
 environment:
-  - nodejs_version: "10.10.0"
+  nodejs_version: "10.10.0"
 
 build_script:
 - sh: ./build.sh RunTests

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,5 @@
+image: Ubuntu1804
+environment:
+  - nodejs_version: 10.10.0
+build_script:
+- sh: ./build.sh RunTests

--- a/install-node.sh
+++ b/install-node.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-
-apt-get update
-curl -sL https://deb.nodesource.com/setup_10.x -o nodesource_setup.sh
-bash nodesource_setup.sh
-apt-get install nodejs -y 

--- a/install-node.sh
+++ b/install-node.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+apt-get update
+curl -sL https://deb.nodesource.com/setup_10.x -o nodesource_setup.sh
+bash nodesource_setup.sh
+apt-get install nodejs -y 

--- a/src/Fable.SimpleJson.fsproj
+++ b/src/Fable.SimpleJson.fsproj
@@ -7,7 +7,7 @@
     <PackageIconUrl></PackageIconUrl>
     <PackageTags>fsharp;fable;json;parser</PackageTags>
     <Authors>Zaid Ajaj</Authors>
-    <Version>2.4.0</Version>
+    <Version>2.5.0</Version>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>

--- a/src/Json.Converter.fs
+++ b/src/Json.Converter.fs
@@ -68,6 +68,7 @@ module Convert =
         | TypeInfo.Array _ -> true
         | TypeInfo.List _ -> true
         | TypeInfo.Seq _ -> true
+        | TypeInfo.Tuple _ -> true
         | _ -> false
 
     let isQuoted (input: string) = 


### PR DESCRIPTION
Fixes #13

Added this test that hopefully should account for every case:
```fs
type AlbumId = AlbumId of int
type AlbumAuthor = AlbumAuthor of string

testCase "Deserializing tuple of single case unions works in Fable 1 representation" <| fun test ->
    [ 
        // Fable 1 -> sent from server
        """
        {
            "Ok": [
                { "AlbumId": 5 }, 
                { "AlbumAuthor": "author" }
            ] 
        }
        """
        // Mix Fable 1 and Fable 2
        """
        [ "Ok", [{ "AlbumId": 5 }, { "AlbumAuthor": "author" }]] 
        """

        """
        { "Ok": [["AlbumId", 5], ["AlbumAuthor", "author"]] } 
        """

        // Fable 2
        """
        [ "Ok", [["AlbumId", 5], ["AlbumAuthor", "author"]]] 
        """
    ]
    |> List.map Json.parseNativeAs<Result<AlbumId * AlbumAuthor, string>>
    |> List.forall (function 
        | Ok (AlbumId 5, AlbumAuthor "author") -> true
        | somethingElse -> false)
    |> test.equal true
``` 