### PR TITLE
Fix anonymous records as generic arguments

### DIFF
--- a/src/Fable.SimpleJson.fsproj
+++ b/src/Fable.SimpleJson.fsproj
@@ -7,7 +7,7 @@
         <PackageIconUrl></PackageIconUrl>
         <PackageTags>fsharp;fable;json;parser</PackageTags>
         <Authors>Zaid Ajaj</Authors>
-        <Version>3.2.0</Version>
+        <Version>3.3.0</Version>
         <TargetFramework>netstandard2.0</TargetFramework>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
     </PropertyGroup>

--- a/src/TypeInfo.Converter.fs
+++ b/src/TypeInfo.Converter.fs
@@ -174,9 +174,16 @@ module Converter =
             // see https://github.com/fable-compiler/Fable/issues/1871
             // Type equality doesn't work for anonymous records - all anon records are considered equal.
             // For anonymous records, the name is the empty string.
-            if not (String.IsNullOrEmpty resolvedType.Name) then
+            let notAnonymousRecord =
+                not (String.IsNullOrEmpty resolvedType.FullName)
+                && not (resolvedType.FullName.EndsWith("`1[]"))
+                && not (resolvedType.FullName.EndsWith("`2[]"))
+
+            if notAnonymousRecord then
                 typeInfoCache.[resolvedType] <- ti
-            ti
+                ti
+            else
+                ti
 
     type Fable.SimpleJson.TypeInfo with
         static member createFrom<'t> ([<Inject>] ?resolver: ITypeResolver<'t>) : Fable.SimpleJson.TypeInfo =

--- a/test/Tests.fs
+++ b/test/Tests.fs
@@ -1767,6 +1767,15 @@ let everyTest =
         |> function
             | Just record -> test.areEqual 1  record.one
             | otherwise -> test.fail()
+
+    testCase "Nested anonymous records with generic unions" <| fun _ ->
+        """
+        {"Just":{"nested":{"name":"John"}}}
+        """
+        |> Json.parseNativeAs<Maybe<{| nested: {| name: string |} |}>>
+        |> function
+            | Just record -> test.areEqual record.nested.name "John"
+            | otherwise -> test.unexpected otherwise
 ]
 
 


### PR DESCRIPTION
@0x53A You might not believe it but I found *yet another edge case* when deserializing anonymous records as generic type arguments