### PR TITLE
Fix deserializaton of generic unions with a tuple/array option type parameter

### DIFF
--- a/src/Json.Converter.fs
+++ b/src/Json.Converter.fs
@@ -85,6 +85,10 @@ module Convert =
         | TypeInfo.Tuple _ -> true
         | _ -> false
 
+    let optional = function
+        | TypeInfo.Option _ -> true
+        | _ -> false
+
     let isQuoted (input: string) =
         input.StartsWith "\"" && input.EndsWith "\""
 
@@ -156,6 +160,10 @@ module Convert =
                     | Some foundCase when Array.length foundCase.CaseTypes = 1 && arrayLike foundCase.CaseTypes.[0] ->
                         let deserialized = fromJsonAs (JArray values) foundCase.CaseTypes.[0]
                         FSharpValue.MakeUnion(foundCase.Info, [| deserialized |])
+                        |> unbox
+                    | Some foundCase when Array.length foundCase.CaseTypes = 1 && optional foundCase.CaseTypes.[0] ->
+                        let parsedOptional = unbox (fromJsonAs (JArray values) foundCase.CaseTypes.[0])
+                        FSharpValue.MakeUnion(foundCase.Info, [| parsedOptional |])
                         |> unbox
                     | Some foundCase ->
                         if Array.length foundCase.CaseTypes = 1

--- a/test/Tests.fs
+++ b/test/Tests.fs
@@ -1828,6 +1828,26 @@ let everyTest =
             match record.value.parent.child with
             | Some child -> test.areEqual child.grandChild "Nested Node"
             | None -> test.fail()
+
+    testCase "Deserializing generic union with tuple option as type parameter" <| fun _ ->
+        """
+        {"ComplexKey": [1, "foo"] }
+        """
+        |> Json.parseNativeAs<ComplexKey<(int * string) option>>
+        |> fun union ->
+            match union with
+            | ComplexKey (Some (1, "foo")) -> test.pass()
+            | ComplexKey _ -> test.fail()
+
+    testCase "Deserializing generic union with nested tuple and options as type parameter" <| fun _ ->
+        """
+        {"ComplexKey": [1, [null, 3]] }
+        """
+        |> Json.parseNativeAs<ComplexKey<(int * (string option * int) option) option>>
+        |> fun union ->
+            match union with
+            | ComplexKey (Some (1, Some (None, 3))) -> test.pass()
+            | ComplexKey _ -> test.fail()
 ]
 
 


### PR DESCRIPTION
Trying to deserialize `{"ComplexKey": [1, "foo"] }` as `ComplexKey<(int * string) option>` would fail with `Expected case 'ComplexKey' to have 1 argument types but the JSON data only contained 2 values`