### PR TITLE
Fix deserialization of longs with units of measure

### DIFF
--- a/src/TypeInfo.Converter.fs
+++ b/src/TypeInfo.Converter.fs
@@ -13,6 +13,7 @@ module Converter =
         | "System.String" -> Some TypeInfo.String
         | "System.Int16" -> Some TypeInfo.Short
         | "System.Int32" -> Some TypeInfo.Int32
+        | "Microsoft.FSharp.Core.int64`1"
         | "System.Int64" -> Some TypeInfo.Long
         | "System.UInt16" -> Some TypeInfo.UInt16
         | "System.UInt32" -> Some TypeInfo.UInt32

--- a/test/Tests.fs
+++ b/test/Tests.fs
@@ -1889,6 +1889,38 @@ let everyTest =
             test.fail()
         with
         | ex -> test.equal "The value '3' is not valid for enum of type 'SimpleEnum'" ex.Message
+
+    testCase "Deserializing int16 with a unit of measure" <| fun _ ->
+        let expected = 5s<someUnit>
+
+        Json.stringify expected
+        |> Json.parseNativeAs<int16<someUnit>>
+        |> fun value ->
+            test.areEqual value expected
+
+    testCase "Deserializing int with a unit of measure" <| fun _ ->
+        let expected = 4<someUnit>
+
+        Json.stringify expected
+        |> Json.parseNativeAs<int<someUnit>>
+        |> fun value ->
+            test.areEqual value expected
+
+    testCase "Deserializing int64 with a unit of measure" <| fun _ ->
+        let expected = 222222222222L<someUnit>
+
+        Json.stringify expected
+        |> Json.parseNativeAs<int64<someUnit>>
+        |> fun value ->
+            test.areEqual value expected
+
+    testCase "Deserializing float with a unit of measure" <| fun _ ->
+        let expected = 42.3333<someUnit>
+
+        Json.stringify expected
+        |> Json.parseNativeAs<float<someUnit>>
+        |> fun value ->
+            test.areEqual value expected
 ]
 
 

--- a/test/Types.fs
+++ b/test/Types.fs
@@ -150,3 +150,6 @@ type AlbumId = AlbumId of int
 type AlbumAuthor = AlbumAuthor of string
 
 type GenericValue<'t> = { value: 't }
+
+[<Measure>]
+type someUnit


### PR DESCRIPTION
Longs with units of measure (but not other primitive types) are for some reason represented as a special type from here https://msdn.microsoft.com/en-us/visualfsharpdocs/conceptual/microsoft.fsharp.core-namespace-[fsharp]