### PR TITLE
Upgrade to Nagareyama

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fable": {
+      "version": "3.0.0-nagareyama-alpha-007",
+      "commands": [
+        "fable"
+      ]
+    }
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.fs.js
 public/bundle.js*
 
 # Node

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,26 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "args": [
+                "-r",
+                "esm",
+                "--timeout",
+                "999999",
+                "--colors",
+                "${workspaceFolder}/dist/tests"
+            ],
+            "internalConsoleOptions": "openOnSessionStart",
+            "name": "Mocha Tests",
+            "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
+            "request": "launch",
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "type": "pwa-node"
+        },
+    ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -724,6 +724,12 @@
                 "to-fast-properties": "^2.0.0"
             }
         },
+        "@types/color-name": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+            "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
+            "dev": true
+        },
         "@types/glob": {
             "version": "7.1.3",
             "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
@@ -1086,6 +1092,105 @@
             "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
             "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
             "dev": true
+        },
+        "array.prototype.map": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/array.prototype.map/-/array.prototype.map-1.0.2.tgz",
+            "integrity": "sha512-Az3OYxgsa1g7xDYp86l0nnN4bcmuEITGe1rbdEBVkrqkzMgDcbdQ2R7r41pNzti+4NMces3H8gMmuioZUilLgw==",
+            "dev": true,
+            "requires": {
+                "define-properties": "^1.1.3",
+                "es-abstract": "^1.17.0-next.1",
+                "es-array-method-boxes-properly": "^1.0.0",
+                "is-string": "^1.0.4"
+            },
+            "dependencies": {
+                "es-abstract": {
+                    "version": "1.17.7",
+                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+                    "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
+                    "dev": true,
+                    "requires": {
+                        "es-to-primitive": "^1.2.1",
+                        "function-bind": "^1.1.1",
+                        "has": "^1.0.3",
+                        "has-symbols": "^1.0.1",
+                        "is-callable": "^1.2.2",
+                        "is-regex": "^1.1.1",
+                        "object-inspect": "^1.8.0",
+                        "object-keys": "^1.1.1",
+                        "object.assign": "^4.1.1",
+                        "string.prototype.trimend": "^1.0.1",
+                        "string.prototype.trimstart": "^1.0.1"
+                    }
+                },
+                "es-to-primitive": {
+                    "version": "1.2.1",
+                    "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+                    "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+                    "dev": true,
+                    "requires": {
+                        "is-callable": "^1.1.4",
+                        "is-date-object": "^1.0.1",
+                        "is-symbol": "^1.0.2"
+                    }
+                },
+                "has-symbols": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+                    "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+                    "dev": true
+                },
+                "is-callable": {
+                    "version": "1.2.2",
+                    "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.2.tgz",
+                    "integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA==",
+                    "dev": true
+                },
+                "is-regex": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
+                    "integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
+                    "dev": true,
+                    "requires": {
+                        "has-symbols": "^1.0.1"
+                    }
+                },
+                "object.assign": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.1.tgz",
+                    "integrity": "sha512-VT/cxmx5yaoHSOTSyrCygIDFco+RsibY2NM0a4RdEeY/4KgqezwFtK1yr3U67xYhqJSlASm2pKhLVzPj2lr4bA==",
+                    "dev": true,
+                    "requires": {
+                        "define-properties": "^1.1.3",
+                        "es-abstract": "^1.18.0-next.0",
+                        "has-symbols": "^1.0.1",
+                        "object-keys": "^1.1.1"
+                    },
+                    "dependencies": {
+                        "es-abstract": {
+                            "version": "1.18.0-next.1",
+                            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
+                            "integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
+                            "dev": true,
+                            "requires": {
+                                "es-to-primitive": "^1.2.1",
+                                "function-bind": "^1.1.1",
+                                "has": "^1.0.3",
+                                "has-symbols": "^1.0.1",
+                                "is-callable": "^1.2.2",
+                                "is-negative-zero": "^2.0.0",
+                                "is-regex": "^1.1.1",
+                                "object-inspect": "^1.8.0",
+                                "object-keys": "^1.1.1",
+                                "object.assign": "^4.1.1",
+                                "string.prototype.trimend": "^1.0.1",
+                                "string.prototype.trimstart": "^1.0.1"
+                            }
+                        }
+                    }
+                }
+            }
         },
         "asn1.js": {
             "version": "4.10.1",
@@ -1546,59 +1651,102 @@
             }
         },
         "chokidar": {
-            "version": "2.1.6",
-            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.6.tgz",
-            "integrity": "sha512-V2jUo67OKkc6ySiRpJrjlpJKl9kDuG+Xb8VgsGzb+aEouhgS1D0weyPU4lEzdAcsCAvrih2J2BqyXqHWvVLw5g==",
+            "version": "3.4.2",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.2.tgz",
+            "integrity": "sha512-IZHaDeBeI+sZJRX7lGcXsdzgvZqKv6sECqsbErJA4mHWfpRrD8B97kSFN4cQz6nGBGiuFia1MKR4d6c1o8Cv7A==",
             "dev": true,
             "requires": {
-                "anymatch": "^2.0.0",
-                "async-each": "^1.0.1",
-                "braces": "^2.3.2",
-                "fsevents": "^1.2.7",
-                "glob-parent": "^3.1.0",
-                "inherits": "^2.0.3",
-                "is-binary-path": "^1.0.0",
-                "is-glob": "^4.0.0",
-                "normalize-path": "^3.0.0",
-                "path-is-absolute": "^1.0.0",
-                "readdirp": "^2.2.1",
-                "upath": "^1.1.1"
+                "anymatch": "~3.1.1",
+                "braces": "~3.0.2",
+                "fsevents": "~2.1.2",
+                "glob-parent": "~5.1.0",
+                "is-binary-path": "~2.1.0",
+                "is-glob": "~4.0.1",
+                "normalize-path": "~3.0.0",
+                "readdirp": "~3.4.0"
             },
             "dependencies": {
-                "glob-parent": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
-                    "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+                "anymatch": {
+                    "version": "3.1.1",
+                    "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+                    "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
                     "dev": true,
                     "requires": {
-                        "is-glob": "^3.1.0",
-                        "path-dirname": "^1.0.0"
-                    },
-                    "dependencies": {
-                        "is-glob": {
-                            "version": "3.1.0",
-                            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-                            "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-                            "dev": true,
-                            "requires": {
-                                "is-extglob": "^2.1.0"
-                            }
-                        }
+                        "normalize-path": "^3.0.0",
+                        "picomatch": "^2.0.4"
                     }
                 },
-                "is-extglob": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-                    "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+                "binary-extensions": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
+                    "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
                     "dev": true
                 },
-                "is-glob": {
-                    "version": "4.0.1",
-                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
-                    "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+                "braces": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+                    "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "^2.1.1"
+                        "fill-range": "^7.0.1"
+                    }
+                },
+                "fill-range": {
+                    "version": "7.0.1",
+                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+                    "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+                    "dev": true,
+                    "requires": {
+                        "to-regex-range": "^5.0.1"
+                    }
+                },
+                "fsevents": {
+                    "version": "2.1.3",
+                    "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+                    "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+                    "dev": true,
+                    "optional": true
+                },
+                "glob-parent": {
+                    "version": "5.1.1",
+                    "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+                    "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+                    "dev": true,
+                    "requires": {
+                        "is-glob": "^4.0.1"
+                    }
+                },
+                "is-binary-path": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+                    "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+                    "dev": true,
+                    "requires": {
+                        "binary-extensions": "^2.0.0"
+                    }
+                },
+                "is-number": {
+                    "version": "7.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+                    "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+                    "dev": true
+                },
+                "readdirp": {
+                    "version": "3.4.0",
+                    "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.4.0.tgz",
+                    "integrity": "sha512-0xe001vZBnJEK+uKcj8qOhyAKPzIT+gStxWr3LCB0DwcXR5NZJ3IaC+yGnHCYzB/S7ov3m3EEbZI2zeNvX+hGQ==",
+                    "dev": true,
+                    "requires": {
+                        "picomatch": "^2.2.1"
+                    }
+                },
+                "to-regex-range": {
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+                    "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+                    "dev": true,
+                    "requires": {
+                        "is-number": "^7.0.0"
                     }
                 }
             }
@@ -1652,21 +1800,43 @@
             }
         },
         "cliui": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
-            "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+            "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
             "dev": true,
             "requires": {
-                "string-width": "^2.1.1",
-                "strip-ansi": "^4.0.0",
-                "wrap-ansi": "^2.0.0"
+                "string-width": "^3.1.0",
+                "strip-ansi": "^5.2.0",
+                "wrap-ansi": "^5.1.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+                    "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+                    "dev": true
+                },
+                "string-width": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+                    "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+                    "dev": true,
+                    "requires": {
+                        "emoji-regex": "^7.0.1",
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^5.1.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+                    "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^4.1.0"
+                    }
+                }
             }
-        },
-        "code-point-at": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-            "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-            "dev": true
         },
         "collection-visit": {
             "version": "1.0.0",
@@ -2087,9 +2257,9 @@
             "dev": true
         },
         "diff": {
-            "version": "3.5.0",
-            "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-            "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+            "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
             "dev": true
         },
         "diffie-hellman": {
@@ -2234,6 +2404,120 @@
                 "object-keys": "^1.0.12"
             }
         },
+        "es-array-method-boxes-properly": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
+            "integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==",
+            "dev": true
+        },
+        "es-get-iterator": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.0.tgz",
+            "integrity": "sha512-UfrmHuWQlNMTs35e1ypnvikg6jCz3SK8v8ImvmDsh36fCVUR1MqoFDiyn0/k52C8NqO3YsO8Oe0azeesNuqSsQ==",
+            "dev": true,
+            "requires": {
+                "es-abstract": "^1.17.4",
+                "has-symbols": "^1.0.1",
+                "is-arguments": "^1.0.4",
+                "is-map": "^2.0.1",
+                "is-set": "^2.0.1",
+                "is-string": "^1.0.5",
+                "isarray": "^2.0.5"
+            },
+            "dependencies": {
+                "es-abstract": {
+                    "version": "1.17.7",
+                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+                    "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
+                    "dev": true,
+                    "requires": {
+                        "es-to-primitive": "^1.2.1",
+                        "function-bind": "^1.1.1",
+                        "has": "^1.0.3",
+                        "has-symbols": "^1.0.1",
+                        "is-callable": "^1.2.2",
+                        "is-regex": "^1.1.1",
+                        "object-inspect": "^1.8.0",
+                        "object-keys": "^1.1.1",
+                        "object.assign": "^4.1.1",
+                        "string.prototype.trimend": "^1.0.1",
+                        "string.prototype.trimstart": "^1.0.1"
+                    }
+                },
+                "es-to-primitive": {
+                    "version": "1.2.1",
+                    "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+                    "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+                    "dev": true,
+                    "requires": {
+                        "is-callable": "^1.1.4",
+                        "is-date-object": "^1.0.1",
+                        "is-symbol": "^1.0.2"
+                    }
+                },
+                "has-symbols": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+                    "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+                    "dev": true
+                },
+                "is-callable": {
+                    "version": "1.2.2",
+                    "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.2.tgz",
+                    "integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA==",
+                    "dev": true
+                },
+                "is-regex": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
+                    "integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
+                    "dev": true,
+                    "requires": {
+                        "has-symbols": "^1.0.1"
+                    }
+                },
+                "isarray": {
+                    "version": "2.0.5",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+                    "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+                    "dev": true
+                },
+                "object.assign": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.1.tgz",
+                    "integrity": "sha512-VT/cxmx5yaoHSOTSyrCygIDFco+RsibY2NM0a4RdEeY/4KgqezwFtK1yr3U67xYhqJSlASm2pKhLVzPj2lr4bA==",
+                    "dev": true,
+                    "requires": {
+                        "define-properties": "^1.1.3",
+                        "es-abstract": "^1.18.0-next.0",
+                        "has-symbols": "^1.0.1",
+                        "object-keys": "^1.1.1"
+                    },
+                    "dependencies": {
+                        "es-abstract": {
+                            "version": "1.18.0-next.1",
+                            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
+                            "integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
+                            "dev": true,
+                            "requires": {
+                                "es-to-primitive": "^1.2.1",
+                                "function-bind": "^1.1.1",
+                                "has": "^1.0.3",
+                                "has-symbols": "^1.0.1",
+                                "is-callable": "^1.2.2",
+                                "is-negative-zero": "^2.0.0",
+                                "is-regex": "^1.1.1",
+                                "object-inspect": "^1.8.0",
+                                "object-keys": "^1.1.1",
+                                "object.assign": "^4.1.1",
+                                "string.prototype.trimend": "^1.0.1",
+                                "string.prototype.trimstart": "^1.0.1"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "es-to-primitive": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
@@ -2266,6 +2550,12 @@
                 "esrecurse": "^4.1.0",
                 "estraverse": "^4.1.1"
             }
+        },
+        "esm": {
+            "version": "3.2.25",
+            "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+            "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
+            "dev": true
         },
         "esprima": {
             "version": "4.0.1",
@@ -2552,41 +2842,6 @@
                 }
             }
         },
-        "fable-babel-plugins": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/fable-babel-plugins/-/fable-babel-plugins-2.3.0.tgz",
-            "integrity": "sha512-alGBNw5HZJzTEznXKfypFEkD5aWsspbCcoVDu9j8Mqdi77dgp4BSjhYSg61mQEg9UluIAZxRM5lhGARYbU97DQ==",
-            "dev": true
-        },
-        "fable-compiler": {
-            "version": "2.10.1",
-            "resolved": "https://registry.npmjs.org/fable-compiler/-/fable-compiler-2.10.1.tgz",
-            "integrity": "sha512-DM4fXrnpyy6cu3cunZoP8bi5ik9av4TXCL5zr+bH8bFgP+X8PCz6Q2JtGJCeaXAgze2fiwotgOS1CdTWEtbwqw==",
-            "dev": true
-        },
-        "fable-loader": {
-            "version": "2.1.9",
-            "resolved": "https://registry.npmjs.org/fable-loader/-/fable-loader-2.1.9.tgz",
-            "integrity": "sha512-ffFfAx4+92yGRjV7iZQOCzqsjQF1he6Lei6hDqfaW1Qjbyx9bhVa8jCX53+I1mhWEw2JWIQpFzwHnYwz2eT4Hw==",
-            "dev": true,
-            "requires": {
-                "fable-babel-plugins": "^2.3.0"
-            }
-        },
-        "fable-splitter": {
-            "version": "2.1.13",
-            "resolved": "https://registry.npmjs.org/fable-splitter/-/fable-splitter-2.1.13.tgz",
-            "integrity": "sha512-eNXQ0uGjCFE6CaJBPSr9J5Bocn66qXLscMmTV5YwjWBJEMG/9UR1TXBm4IPMEpT4tQbyYZI+Wj/hWRf3C7thOw==",
-            "dev": true,
-            "requires": {
-                "@babel/core": "^7.1.6",
-                "@babel/plugin-transform-modules-commonjs": "^7.1.0",
-                "chalk": "^2.4.1",
-                "chokidar": "^2.0.4",
-                "fable-babel-plugins": "^2.3.0",
-                "fs-extra": "^7.0.0"
-            }
-        },
         "fast-deep-equal": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
@@ -2711,9 +2966,9 @@
             },
             "dependencies": {
                 "is-buffer": {
-                    "version": "2.0.3",
-                    "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
-                    "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw==",
+                    "version": "2.0.4",
+                    "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+                    "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
                     "dev": true
                 }
             }
@@ -2769,17 +3024,6 @@
             "requires": {
                 "inherits": "^2.0.1",
                 "readable-stream": "^2.0.0"
-            }
-        },
-        "fs-extra": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-            "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
-            "dev": true,
-            "requires": {
-                "graceful-fs": "^4.1.2",
-                "jsonfile": "^4.0.0",
-                "universalify": "^0.1.0"
             }
         },
         "fs-write-stream-atomic": {
@@ -3355,9 +3599,9 @@
             "dev": true
         },
         "get-caller-file": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
-            "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+            "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
             "dev": true
         },
         "get-stream": {
@@ -3807,12 +4051,6 @@
                 "loose-envify": "^1.0.0"
             }
         },
-        "invert-kv": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
-            "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
-            "dev": true
-        },
         "ip": {
             "version": "1.1.5",
             "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
@@ -3956,6 +4194,18 @@
                 "is-extglob": "^2.1.1"
             }
         },
+        "is-map": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.1.tgz",
+            "integrity": "sha512-T/S49scO8plUiAOA2DBTBG3JHpn1yiw0kRp6dgiZ0v2/6twi5eiB0rHtHFH9ZIrvlWc6+4O+m4zg5+Z833aXgw==",
+            "dev": true
+        },
+        "is-negative-zero": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.0.tgz",
+            "integrity": "sha1-lVOxIbD6wohp2p7UWeIMdUN4hGE=",
+            "dev": true
+        },
         "is-number": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
@@ -4000,6 +4250,12 @@
                 "path-is-inside": "^1.0.2"
             }
         },
+        "is-plain-obj": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+            "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+            "dev": true
+        },
         "is-plain-object": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
@@ -4018,10 +4274,22 @@
                 "has": "^1.0.1"
             }
         },
+        "is-set": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.1.tgz",
+            "integrity": "sha512-eJEzOtVyenDs1TMzSQ3kU3K+E0GUS9sno+F0OBT97xsgcJsF9nXMBtkT9/kut5JEpM7oL7X/0qxR17K3mcwIAA==",
+            "dev": true
+        },
         "is-stream": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
             "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+            "dev": true
+        },
+        "is-string": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
+            "integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==",
             "dev": true
         },
         "is-symbol": {
@@ -4063,6 +4331,22 @@
             "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
             "dev": true
         },
+        "iterate-iterator": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/iterate-iterator/-/iterate-iterator-1.0.1.tgz",
+            "integrity": "sha512-3Q6tudGN05kbkDQDI4CqjaBf4qf85w6W6GnuZDtUVYwKgtC1q8yxYX7CZed7N+tLzQqS6roujWvszf13T+n9aw==",
+            "dev": true
+        },
+        "iterate-value": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/iterate-value/-/iterate-value-1.0.2.tgz",
+            "integrity": "sha512-A6fMAio4D2ot2r/TYzr4yUWrmwNdsN5xL7+HUiyACE4DXm+q8HtPcnFTp+NnW3k4N05tZ7FVYFFb2CR13NxyHQ==",
+            "dev": true,
+            "requires": {
+                "es-get-iterator": "^1.0.2",
+                "iterate-iterator": "^1.0.1"
+            }
+        },
         "js-levenshtein": {
             "version": "1.1.6",
             "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
@@ -4076,9 +4360,9 @@
             "dev": true
         },
         "js-yaml": {
-            "version": "3.13.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-            "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+            "version": "3.14.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
+            "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
             "dev": true,
             "requires": {
                 "argparse": "^1.0.7",
@@ -4118,15 +4402,6 @@
                 "minimist": "^1.2.0"
             }
         },
-        "jsonfile": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-            "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-            "dev": true,
-            "requires": {
-                "graceful-fs": "^4.1.6"
-            }
-        },
         "killable": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/killable/-/killable-1.0.1.tgz",
@@ -4138,15 +4413,6 @@
             "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
             "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
             "dev": true
-        },
-        "lcid": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
-            "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
-            "dev": true,
-            "requires": {
-                "invert-kv": "^2.0.0"
-            }
         },
         "loader-runner": {
             "version": "2.4.0",
@@ -4193,12 +4459,64 @@
             "dev": true
         },
         "log-symbols": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
-            "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.0.0.tgz",
+            "integrity": "sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==",
             "dev": true,
             "requires": {
-                "chalk": "^2.0.1"
+                "chalk": "^4.0.0"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+                    "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
             }
         },
         "loglevel": {
@@ -4234,15 +4552,6 @@
                 "pify": "^3.0.0"
             }
         },
-        "map-age-cleaner": {
-            "version": "0.1.3",
-            "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
-            "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
-            "dev": true,
-            "requires": {
-                "p-defer": "^1.0.0"
-            }
-        },
         "map-cache": {
             "version": "0.2.2",
             "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
@@ -4274,17 +4583,6 @@
             "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
             "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
             "dev": true
-        },
-        "mem": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
-            "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
-            "dev": true,
-            "requires": {
-                "map-age-cleaner": "^0.1.1",
-                "mimic-fn": "^2.0.0",
-                "p-is-promise": "^2.0.0"
-            }
         },
         "memory-fs": {
             "version": "0.4.1",
@@ -4359,12 +4657,6 @@
             "requires": {
                 "mime-db": "1.44.0"
             }
-        },
-        "mimic-fn": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-            "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-            "dev": true
         },
         "minimalistic-assert": {
             "version": "1.0.1",
@@ -4442,76 +4734,64 @@
             }
         },
         "mocha": {
-            "version": "6.2.0",
-            "resolved": "https://registry.npmjs.org/mocha/-/mocha-6.2.0.tgz",
-            "integrity": "sha512-qwfFgY+7EKAAUAdv7VYMZQknI7YJSGesxHyhn6qD52DV8UcSZs5XwCifcZGMVIE4a5fbmhvbotxC0DLQ0oKohQ==",
+            "version": "8.1.3",
+            "resolved": "https://registry.npmjs.org/mocha/-/mocha-8.1.3.tgz",
+            "integrity": "sha512-ZbaYib4hT4PpF4bdSO2DohooKXIn4lDeiYqB+vTmCdr6l2woW0b6H3pf5x4sM5nwQMru9RvjjHYWVGltR50ZBw==",
             "dev": true,
             "requires": {
-                "ansi-colors": "3.2.3",
+                "ansi-colors": "4.1.1",
                 "browser-stdout": "1.3.1",
-                "debug": "3.2.6",
-                "diff": "3.5.0",
-                "escape-string-regexp": "1.0.5",
-                "find-up": "3.0.0",
-                "glob": "7.1.3",
+                "chokidar": "3.4.2",
+                "debug": "4.1.1",
+                "diff": "4.0.2",
+                "escape-string-regexp": "4.0.0",
+                "find-up": "5.0.0",
+                "glob": "7.1.6",
                 "growl": "1.10.5",
                 "he": "1.2.0",
-                "js-yaml": "3.13.1",
-                "log-symbols": "2.2.0",
+                "js-yaml": "3.14.0",
+                "log-symbols": "4.0.0",
                 "minimatch": "3.0.4",
-                "mkdirp": "0.5.1",
-                "ms": "2.1.1",
-                "node-environment-flags": "1.0.5",
+                "ms": "2.1.2",
                 "object.assign": "4.1.0",
-                "strip-json-comments": "2.0.1",
-                "supports-color": "6.0.0",
-                "which": "1.3.1",
+                "promise.allsettled": "1.0.2",
+                "serialize-javascript": "4.0.0",
+                "strip-json-comments": "3.0.1",
+                "supports-color": "7.1.0",
+                "which": "2.0.2",
                 "wide-align": "1.1.3",
-                "yargs": "13.2.2",
-                "yargs-parser": "13.0.0",
-                "yargs-unparser": "1.5.0"
+                "workerpool": "6.0.0",
+                "yargs": "13.3.2",
+                "yargs-parser": "13.1.2",
+                "yargs-unparser": "1.6.1"
             },
             "dependencies": {
                 "ansi-colors": {
-                    "version": "3.2.3",
-                    "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
-                    "integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==",
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+                    "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
                     "dev": true
                 },
-                "ansi-regex": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-                    "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+                "escape-string-regexp": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+                    "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
                     "dev": true
-                },
-                "debug": {
-                    "version": "3.2.6",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-                    "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-                    "dev": true,
-                    "requires": {
-                        "ms": "^2.1.1"
-                    }
                 },
                 "find-up": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-                    "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+                    "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
                     "dev": true,
                     "requires": {
-                        "locate-path": "^3.0.0"
+                        "locate-path": "^6.0.0",
+                        "path-exists": "^4.0.0"
                     }
                 },
-                "get-caller-file": {
-                    "version": "2.0.5",
-                    "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-                    "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-                    "dev": true
-                },
                 "glob": {
-                    "version": "7.1.3",
-                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-                    "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+                    "version": "7.1.6",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+                    "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
                     "dev": true,
                     "requires": {
                         "fs.realpath": "^1.0.0",
@@ -4522,53 +4802,37 @@
                         "path-is-absolute": "^1.0.0"
                     }
                 },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
                 "locate-path": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-                    "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+                    "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
                     "dev": true,
                     "requires": {
-                        "p-locate": "^3.0.0",
-                        "path-exists": "^3.0.0"
+                        "p-locate": "^5.0.0"
                     }
-                },
-                "minimist": {
-                    "version": "0.0.8",
-                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                    "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-                    "dev": true
-                },
-                "mkdirp": {
-                    "version": "0.5.1",
-                    "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-                    "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-                    "dev": true,
-                    "requires": {
-                        "minimist": "0.0.8"
-                    }
-                },
-                "ms": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-                    "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-                    "dev": true
                 },
                 "p-limit": {
-                    "version": "2.2.0",
-                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
-                    "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.0.2.tgz",
+                    "integrity": "sha512-iwqZSOoWIW+Ew4kAGUlN16J4M7OB3ysMLSZtnhmqx7njIHFPlxWBX8xo3lVTyFVq6mI/lL9qt2IsN1sHwaxJkg==",
                     "dev": true,
                     "requires": {
                         "p-try": "^2.0.0"
                     }
                 },
                 "p-locate": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-                    "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+                    "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
                     "dev": true,
                     "requires": {
-                        "p-limit": "^2.0.0"
+                        "p-limit": "^3.0.2"
                     }
                 },
                 "p-try": {
@@ -4577,68 +4841,28 @@
                     "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
                     "dev": true
                 },
-                "require-main-filename": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-                    "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+                "path-exists": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+                    "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
                     "dev": true
                 },
-                "string-width": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-                    "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-                    "dev": true,
-                    "requires": {
-                        "emoji-regex": "^7.0.1",
-                        "is-fullwidth-code-point": "^2.0.0",
-                        "strip-ansi": "^5.1.0"
-                    }
-                },
-                "strip-ansi": {
-                    "version": "5.2.0",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-                    "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "^4.1.0"
-                    }
-                },
                 "supports-color": {
-                    "version": "6.0.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
-                    "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+                    "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "^3.0.0"
+                        "has-flag": "^4.0.0"
                     }
                 },
-                "yargs": {
-                    "version": "13.2.2",
-                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.2.2.tgz",
-                    "integrity": "sha512-WyEoxgyTD3w5XRpAQNYUB9ycVH/PQrToaTXdYXRdOXvEy1l19br+VJsc0vcO8PTGg5ro/l/GY7F/JMEBmI0BxA==",
+                "which": {
+                    "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+                    "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
                     "dev": true,
                     "requires": {
-                        "cliui": "^4.0.0",
-                        "find-up": "^3.0.0",
-                        "get-caller-file": "^2.0.1",
-                        "os-locale": "^3.1.0",
-                        "require-directory": "^2.1.1",
-                        "require-main-filename": "^2.0.0",
-                        "set-blocking": "^2.0.0",
-                        "string-width": "^3.0.0",
-                        "which-module": "^2.0.0",
-                        "y18n": "^4.0.0",
-                        "yargs-parser": "^13.0.0"
-                    }
-                },
-                "yargs-parser": {
-                    "version": "13.0.0",
-                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.0.0.tgz",
-                    "integrity": "sha512-w2LXjoL8oRdRQN+hOyppuXs+V/fVAYtpcrRxZuF7Kt/Oc+Jr2uAcVntaUTNT6w5ihoWfFDpNY8CPx1QskxZ/pw==",
-                    "dev": true,
-                    "requires": {
-                        "camelcase": "^5.0.0",
-                        "decamelize": "^1.2.0"
+                        "isexe": "^2.0.0"
                     }
                 }
             }
@@ -4731,20 +4955,10 @@
             "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
             "dev": true
         },
-        "node-environment-flags": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.5.tgz",
-            "integrity": "sha512-VNYPRfGfmZLx0Ye20jWzHUjyTW/c+6Wq+iLhDzUI4XmhrDd9l/FozXV3F2xOaXjvp0co0+v1YSR3CMP6g+VvLQ==",
-            "dev": true,
-            "requires": {
-                "object.getownpropertydescriptors": "^2.0.3",
-                "semver": "^5.7.0"
-            }
-        },
         "node-forge": {
-            "version": "0.9.0",
-            "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.0.tgz",
-            "integrity": "sha512-7ASaDa3pD+lJ3WvXFsxekJQelBKRpne+GOVbLbtHYdd7pFspyeuJHnWfLplGf3SwKGbfs/aYl5V/JCIaHVUKKQ==",
+            "version": "0.10.0",
+            "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
+            "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
             "dev": true
         },
         "node-libs-browser": {
@@ -4809,12 +5023,6 @@
             "requires": {
                 "path-key": "^2.0.0"
             }
-        },
-        "number-is-nan": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-            "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-            "dev": true
         },
         "object-assign": {
             "version": "4.1.1",
@@ -5022,33 +5230,10 @@
             "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=",
             "dev": true
         },
-        "os-locale": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
-            "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
-            "dev": true,
-            "requires": {
-                "execa": "^1.0.0",
-                "lcid": "^2.0.0",
-                "mem": "^4.0.0"
-            }
-        },
-        "p-defer": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
-            "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
-            "dev": true
-        },
         "p-finally": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
             "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-            "dev": true
-        },
-        "p-is-promise": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.1.0.tgz",
-            "integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==",
             "dev": true
         },
         "p-limit": {
@@ -5204,8 +5389,7 @@
             "version": "2.2.2",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
             "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
-            "dev": true,
-            "optional": true
+            "dev": true
         },
         "pify": {
             "version": "3.0.0",
@@ -5288,6 +5472,106 @@
             "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
             "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
             "dev": true
+        },
+        "promise.allsettled": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/promise.allsettled/-/promise.allsettled-1.0.2.tgz",
+            "integrity": "sha512-UpcYW5S1RaNKT6pd+s9jp9K9rlQge1UXKskec0j6Mmuq7UJCvlS2J2/s/yuPN8ehftf9HXMxWlKiPbGGUzpoRg==",
+            "dev": true,
+            "requires": {
+                "array.prototype.map": "^1.0.1",
+                "define-properties": "^1.1.3",
+                "es-abstract": "^1.17.0-next.1",
+                "function-bind": "^1.1.1",
+                "iterate-value": "^1.0.0"
+            },
+            "dependencies": {
+                "es-abstract": {
+                    "version": "1.17.7",
+                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+                    "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
+                    "dev": true,
+                    "requires": {
+                        "es-to-primitive": "^1.2.1",
+                        "function-bind": "^1.1.1",
+                        "has": "^1.0.3",
+                        "has-symbols": "^1.0.1",
+                        "is-callable": "^1.2.2",
+                        "is-regex": "^1.1.1",
+                        "object-inspect": "^1.8.0",
+                        "object-keys": "^1.1.1",
+                        "object.assign": "^4.1.1",
+                        "string.prototype.trimend": "^1.0.1",
+                        "string.prototype.trimstart": "^1.0.1"
+                    }
+                },
+                "es-to-primitive": {
+                    "version": "1.2.1",
+                    "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+                    "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+                    "dev": true,
+                    "requires": {
+                        "is-callable": "^1.1.4",
+                        "is-date-object": "^1.0.1",
+                        "is-symbol": "^1.0.2"
+                    }
+                },
+                "has-symbols": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+                    "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+                    "dev": true
+                },
+                "is-callable": {
+                    "version": "1.2.2",
+                    "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.2.tgz",
+                    "integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA==",
+                    "dev": true
+                },
+                "is-regex": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
+                    "integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
+                    "dev": true,
+                    "requires": {
+                        "has-symbols": "^1.0.1"
+                    }
+                },
+                "object.assign": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.1.tgz",
+                    "integrity": "sha512-VT/cxmx5yaoHSOTSyrCygIDFco+RsibY2NM0a4RdEeY/4KgqezwFtK1yr3U67xYhqJSlASm2pKhLVzPj2lr4bA==",
+                    "dev": true,
+                    "requires": {
+                        "define-properties": "^1.1.3",
+                        "es-abstract": "^1.18.0-next.0",
+                        "has-symbols": "^1.0.1",
+                        "object-keys": "^1.1.1"
+                    },
+                    "dependencies": {
+                        "es-abstract": {
+                            "version": "1.18.0-next.1",
+                            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
+                            "integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
+                            "dev": true,
+                            "requires": {
+                                "es-to-primitive": "^1.2.1",
+                                "function-bind": "^1.1.1",
+                                "has": "^1.0.3",
+                                "has-symbols": "^1.0.1",
+                                "is-callable": "^1.2.2",
+                                "is-negative-zero": "^2.0.0",
+                                "is-regex": "^1.1.1",
+                                "object-inspect": "^1.8.0",
+                                "object-keys": "^1.1.1",
+                                "object.assign": "^4.1.1",
+                                "string.prototype.trimend": "^1.0.1",
+                                "string.prototype.trimstart": "^1.0.1"
+                            }
+                        }
+                    }
+                }
+            }
         },
         "proxy-addr": {
             "version": "2.0.6",
@@ -5618,9 +5902,9 @@
             "dev": true
         },
         "require-main-filename": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-            "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+            "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
             "dev": true
         },
         "requires-port": {
@@ -5760,12 +6044,12 @@
             "dev": true
         },
         "selfsigned": {
-            "version": "1.10.7",
-            "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.7.tgz",
-            "integrity": "sha512-8M3wBCzeWIJnQfl43IKwOmC4H/RAp50S8DF60znzjW5GVqTcSe2vWclt7hmYVPkKPlHWOu5EaWOMZ2Y6W8ZXTA==",
+            "version": "1.10.8",
+            "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.8.tgz",
+            "integrity": "sha512-2P4PtieJeEwVgTU9QEcwIRDQ/mXJLX8/+I3ur+Pg16nS8oNbrGxEso9NyYWy8NAmXiNl4dlAp5MwoNeCWzON4w==",
             "dev": true,
             "requires": {
-                "node-forge": "0.9.0"
+                "node-forge": "^0.10.0"
             }
         },
         "semver": {
@@ -5818,6 +6102,15 @@
                     "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
                     "dev": true
                 }
+            }
+        },
+        "serialize-javascript": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
+            "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
+            "dev": true,
+            "requires": {
+                "randombytes": "^2.1.0"
             }
         },
         "serve-index": {
@@ -6467,9 +6760,9 @@
             "dev": true
         },
         "strip-json-comments": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-            "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
+            "integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==",
             "dev": true
         },
         "supports-color": {
@@ -6845,12 +7138,6 @@
             "requires": {
                 "imurmurhash": "^0.1.4"
             }
-        },
-        "universalify": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-            "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-            "dev": true
         },
         "unpipe": {
             "version": "1.0.0",
@@ -7789,49 +8076,47 @@
                 "errno": "~0.1.7"
             }
         },
+        "workerpool": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.0.0.tgz",
+            "integrity": "sha512-fU2OcNA/GVAJLLyKUoHkAgIhKb0JoCpSjLC/G2vYKxUjVmQwGbRVeoPJ1a8U4pnVofz4AQV5Y/NEw8oKqxEBtA==",
+            "dev": true
+        },
         "wrap-ansi": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-            "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+            "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
             "dev": true,
             "requires": {
-                "string-width": "^1.0.1",
-                "strip-ansi": "^3.0.1"
+                "ansi-styles": "^3.2.0",
+                "string-width": "^3.0.0",
+                "strip-ansi": "^5.0.0"
             },
             "dependencies": {
                 "ansi-regex": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+                    "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
                     "dev": true
                 },
-                "is-fullwidth-code-point": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-                    "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-                    "dev": true,
-                    "requires": {
-                        "number-is-nan": "^1.0.0"
-                    }
-                },
                 "string-width": {
-                    "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-                    "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+                    "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
                     "dev": true,
                     "requires": {
-                        "code-point-at": "^1.0.0",
-                        "is-fullwidth-code-point": "^1.0.0",
-                        "strip-ansi": "^3.0.0"
+                        "emoji-regex": "^7.0.1",
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^5.1.0"
                     }
                 },
                 "strip-ansi": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+                    "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "^2.0.0"
+                        "ansi-regex": "^4.1.0"
                     }
                 }
             }
@@ -7870,25 +8155,29 @@
             "dev": true
         },
         "yargs": {
-            "version": "12.0.5",
-            "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
-            "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
+            "version": "13.3.2",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
+            "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
             "dev": true,
             "requires": {
-                "cliui": "^4.0.0",
-                "decamelize": "^1.2.0",
+                "cliui": "^5.0.0",
                 "find-up": "^3.0.0",
-                "get-caller-file": "^1.0.1",
-                "os-locale": "^3.0.0",
+                "get-caller-file": "^2.0.1",
                 "require-directory": "^2.1.1",
-                "require-main-filename": "^1.0.1",
+                "require-main-filename": "^2.0.0",
                 "set-blocking": "^2.0.0",
-                "string-width": "^2.0.0",
+                "string-width": "^3.0.0",
                 "which-module": "^2.0.0",
-                "y18n": "^3.2.1 || ^4.0.0",
-                "yargs-parser": "^11.1.1"
+                "y18n": "^4.0.0",
+                "yargs-parser": "^13.1.2"
             },
             "dependencies": {
+                "ansi-regex": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+                    "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+                    "dev": true
+                },
                 "find-up": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
@@ -7909,9 +8198,9 @@
                     }
                 },
                 "p-limit": {
-                    "version": "2.2.0",
-                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
-                    "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+                    "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
                     "dev": true,
                     "requires": {
                         "p-try": "^2.0.0"
@@ -7931,13 +8220,33 @@
                     "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
                     "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
                     "dev": true
+                },
+                "string-width": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+                    "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+                    "dev": true,
+                    "requires": {
+                        "emoji-regex": "^7.0.1",
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^5.1.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+                    "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^4.1.0"
+                    }
                 }
             }
         },
         "yargs-parser": {
-            "version": "11.1.1",
-            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
-            "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
+            "version": "13.1.2",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+            "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
             "dev": true,
             "requires": {
                 "camelcase": "^5.0.0",
@@ -7945,14 +8254,116 @@
             }
         },
         "yargs-unparser": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.5.0.tgz",
-            "integrity": "sha512-HK25qidFTCVuj/D1VfNiEndpLIeJN78aqgR23nL3y4N0U/91cOAzqfHlF8n2BvoNDcZmJKin3ddNSvOxSr8flw==",
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.6.1.tgz",
+            "integrity": "sha512-qZV14lK9MWsGCmcr7u5oXGH0dbGqZAIxTDrWXZDo5zUr6b6iUmelNKO6x6R1dQT24AH3LgRxJpr8meWy2unolA==",
             "dev": true,
             "requires": {
+                "camelcase": "^5.3.1",
+                "decamelize": "^1.2.0",
                 "flat": "^4.1.0",
-                "lodash": "^4.17.11",
-                "yargs": "^12.0.5"
+                "is-plain-obj": "^1.1.0",
+                "yargs": "^14.2.3"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+                    "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+                    "dev": true
+                },
+                "find-up": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+                    "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "^3.0.0"
+                    }
+                },
+                "locate-path": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+                    "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+                    "dev": true,
+                    "requires": {
+                        "p-locate": "^3.0.0",
+                        "path-exists": "^3.0.0"
+                    }
+                },
+                "p-limit": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+                    "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+                    "dev": true,
+                    "requires": {
+                        "p-try": "^2.0.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+                    "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+                    "dev": true,
+                    "requires": {
+                        "p-limit": "^2.0.0"
+                    }
+                },
+                "p-try": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+                    "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+                    "dev": true
+                },
+                "string-width": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+                    "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+                    "dev": true,
+                    "requires": {
+                        "emoji-regex": "^7.0.1",
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^5.1.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+                    "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^4.1.0"
+                    }
+                },
+                "yargs": {
+                    "version": "14.2.3",
+                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-14.2.3.tgz",
+                    "integrity": "sha512-ZbotRWhF+lkjijC/VhmOT9wSgyBQ7+zr13+YLkhfsSiTriYsMzkTUFP18pFhWwBeMa5gUc1MzbhrO6/VB7c9Xg==",
+                    "dev": true,
+                    "requires": {
+                        "cliui": "^5.0.0",
+                        "decamelize": "^1.2.0",
+                        "find-up": "^3.0.0",
+                        "get-caller-file": "^2.0.1",
+                        "require-directory": "^2.1.1",
+                        "require-main-filename": "^2.0.0",
+                        "set-blocking": "^2.0.0",
+                        "string-width": "^3.0.0",
+                        "which-module": "^2.0.0",
+                        "y18n": "^4.0.0",
+                        "yargs-parser": "^15.0.1"
+                    }
+                },
+                "yargs-parser": {
+                    "version": "15.0.1",
+                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.1.tgz",
+                    "integrity": "sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==",
+                    "dev": true,
+                    "requires": {
+                        "camelcase": "^5.0.0",
+                        "decamelize": "^1.2.0"
+                    }
+                }
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -3,19 +3,17 @@
     "scripts": {
         "build": "webpack-cli --mode production",
         "start": "webpack-dev-server",
-        "pretest": "fable-splitter test -o dist/tests --commonjs",
-        "test": "mocha dist/tests",
-        "headless-tests": "webpack-cli --mode production && dotnet run --project ./headless/Headless.fsproj"
+        "pretest": "dotnet fable test --outDir dist/tests",
+        "test": "mocha dist/tests -r esm",
+        "headless-tests": "dotnet fable test && webpack-cli --mode production && dotnet run --project ./headless/Headless.fsproj"
     },
     "devDependencies": {
         "@babel/core": "^7.0.0",
         "@babel/polyfill": "^7.0.0",
         "@babel/preset-env": "^7.0.0",
         "babel-loader": "^8.0.0",
-        "fable-compiler": "^2.10.1",
-        "fable-loader": "^2.1.9",
-        "fable-splitter": "^2.1.13",
-        "mocha": "^6.2.0",
+        "esm": "^3.2.25",
+        "mocha": "^8.1.3",
         "webpack": "^4.27.1",
         "webpack-cli": "^3.3.12",
         "webpack-dev-server": "^3.11.0"

--- a/src/Json.Converter.fs
+++ b/src/Json.Converter.fs
@@ -251,8 +251,8 @@ module Convert =
                         failwithf "Union of records of type '%s' cannot be deserialized with the value of the discriminator key is not a string to match against a specific union case" unionType.Name
             | otherwise ->
                 // TODO!!! Better error messages here
-                let unexpectedJson = JS.JSON.stringify otherwise
-                let expectedType = JS.JSON.stringify cases
+                let unexpectedJson = string otherwise
+                let expectedType = string cases
                 failwithf "Expected JSON:\n%s\nto match the type\n%s" unexpectedJson expectedType
         | JNull, TypeInfo.Option _ -> unbox None
         | jsonValue, TypeInfo.Option optionalTypeDelayed when jsonValue <> JNull ->
@@ -337,8 +337,8 @@ module Convert =
                         FSharpValue.MakeUnion(caseInfo, parsedValues)
                         |> unbox
             | otherwise ->
-                let unexpectedJson = JS.JSON.stringify otherwise
-                let expectedType = JS.JSON.stringify cases
+                let unexpectedJson = string otherwise
+                let expectedType = string cases
                 failwithf "Expected JSON:\n%s\nto match the type\n%s" unexpectedJson expectedType
         // Arrays
         | JArray values, TypeInfo.Array elementTypeDelayed ->
@@ -533,7 +533,7 @@ module Convert =
             let unknownType = getType()
             failwithf "Cannot convert %s to %s" (SimpleJson.toString input) unknownType.FullName
         | _ ->
-            failwithf "Cannot convert %s to %s" (SimpleJson.toString input) (JS.JSON.stringify typeInfo)
+            failwithf "Cannot convert %s to %s" (SimpleJson.toString input) (string typeInfo)
 
     let fromJson<'t> json typeInfo =
         unbox<'t> (fromJsonAs json typeInfo)

--- a/src/SimpleJson.fs
+++ b/src/SimpleJson.fs
@@ -66,11 +66,11 @@ module SimpleJson =
         if isNullOrUndefined value
         then JS.JSON.stringify(null)
         else JS.JSON.stringify(value, (fun key v ->
-            if isDateOffset (get key jsThis) then
-                let dateOffset : DateTimeOffset = get key jsThis
+            if isDateOffset v then
+                let dateOffset : DateTimeOffset = !!v
                 box (dateOffset.ToString("O"))
-            elif isBigInt (get key jsThis) then
-                let bigInt : bigint = get key jsThis
+            elif isBigInt v then
+                let bigInt : bigint = !!v
                 box (string (decimal bigInt))
             else
             match v with

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -18,7 +18,7 @@ module.exports = function (evn, argv) {
   mode: mode,
   devtool: isProduction ? false : "eval-source-map",
   entry: {
-    app: ["@babel/polyfill", "./test/Tests.fsproj"]
+    app: ["@babel/polyfill", "./test/Tests.fs.js"]
   },
   output: {
     filename: 'bundle.js',
@@ -30,10 +30,6 @@ module.exports = function (evn, argv) {
   },
   module: {
     rules: [
-      {
-        test: /\.fs(x|proj)?$/,
-        use: "fable-loader"
-      },
       {
         test: /\.js$/,
         exclude: /node_modules/,


### PR DESCRIPTION
This uses Nagareyama instead of fable-splitter to run the tests. In order to run ES2015 modules directly, I'm passing the `-r esm` option to Mocha.

I made a few minor code changes but some tests are still failing. I know we don't want to make breaking code changes in Fable 3 but some things in SimpleJson depend on Fable or even F# implementation specifics and can easily break so it'd be nice to fix those. For example the FSharpMap and FSharpSet internal representation are changing in FSharp.Core and we're porting the change to Fable: https://github.com/dotnet/fsharp/pull/10188

It's true that testing the type of a dynamic object is tricky in Fable. Nagareyama is removing the restriction of testing generic types (although the type parameters are still ignored) maybe that could help. We could also includes some methods in Fable.Core.Reflection like `isMap`, `isSet`, isDictionary`, etc.