### PR TITLE
Support for escaped utf16 characters

### DIFF
--- a/test/Tests.fs
+++ b/test/Tests.fs
@@ -247,6 +247,11 @@ let fable2xTests =
         |> List.choose SimpleJson.tryParse
         |> test.areEqual [JString "there is some json inside"; JString ""]
 
+    testCase "Json parser works with escaped utf-16 character" <| fun _ ->
+        ["\"It\\u0027s coming rome\""]
+        |> List.choose SimpleJson.tryParse
+        |> test.areEqual [JString "It's coming rome"]
+
     testCase "Json parser can parse escaped empty objects" <| fun _ ->
         match SimpleJson.tryParse """ {} """ with
         | Some _ -> test.pass()


### PR DESCRIPTION
SimpleJson.parse fails when input json contains a string with utf16 escaped sequences. 
For example, I've gotten parsing error, trying to parse json with `"It\u0027s coming rome"`

However, according to [JSON RFC, section 2.5](https://datatracker.ietf.org/doc/html/rfc4627#section-2.5), is it legal escape sequence:
```
Any character may be escaped.  If the character is in the Basic
   Multilingual Plane (U+0000 through U+FFFF), then it may be
   represented as a six-character sequence: a reverse solidus, followed
   by the lowercase letter u, followed by four hexadecimal digits that
   encode the character's code point.  The hexadecimal letters A though
   F can be upper or lowercase.  So, for example, a string containing
   only a single reverse solidus character may be represented as
   "\u005C".
```
The change adds support for escaped utf16 characters 
