### PR TITLE
Support TimeOnly, DateOnly

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "fable": {
-      "version": "3.2.3",
+      "version": "3.6.0-beta-001",
       "commands": [
         "fable"
       ]

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-image: Ubuntu1804
+image: Ubuntu2004
 
 stack: node 10
 
@@ -6,6 +6,7 @@ environment:
   nodejs_version: "10.10.0"
 
 build_script:
+- sh: sudo apt-get install -y dotnet-sdk-6.0
 - sh: ./build.sh RunTests
 
 test: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ environment:
   nodejs_version: "10.10.0"
 
 build_script:
-- sh: sudo apt-get install -y dotnet-sdk-6.0
+- sh: sudo apt-get update && sudo apt-get install -y dotnet-sdk-6.0
 - sh: ./build.sh RunTests
 
 test: off

--- a/package.json
+++ b/package.json
@@ -2,13 +2,13 @@
     "private": true,
     "scripts": {
         "build": "webpack-cli --mode production",
-        "build-nagareyama": "dotnet fable test && webpack-cli --mode production --config webpack.nagareyama.js",
+        "build-nagareyama": "dotnet fable test --define NAGAREYAMA && webpack-cli --mode production --config webpack.nagareyama.js",
         "start": "webpack-dev-server",
         "start-nagareyama": "webpack-dev-server --config webpack.nagareyama.js",
-        "watch-nagareyama": "dotnet fable watch test --run webpack-dev-server --config webpack.nagareyama.js",
+        "watch-nagareyama": "dotnet fable watch test --define NAGAREYAMA --run webpack-dev-server --config webpack.nagareyama.js",
         "pretest": "fable-splitter test -o dist/tests --commonjs",
         "test": "mocha dist/tests",
-        "test-nagareyama": "dotnet tool restore && dotnet fable test --outDir dist/tests && mocha dist/tests -r esm",
+        "test-nagareyama": "dotnet tool restore && dotnet fable test --define NAGAREYAMA --outDir dist/tests && mocha dist/tests -r esm",
         "headless-tests": "webpack-cli --mode production && dotnet run --project ./headless/Headless.fsproj",
         "headless-nagareyama-tests": "npm run build-nagareyama && dotnet run --project ./headless/Headless.fsproj"
     },

--- a/src/Fable.SimpleJson.fsproj
+++ b/src/Fable.SimpleJson.fsproj
@@ -8,7 +8,7 @@
         <PackageTags>fsharp;fable;json;parser</PackageTags>
         <Authors>Zaid Ajaj</Authors>
         <Version>3.21.0</Version>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
     </PropertyGroup>
     <ItemGroup>

--- a/src/TypeInfo.Converter.fs
+++ b/src/TypeInfo.Converter.fs
@@ -20,6 +20,8 @@ module Converter =
         | "System.UInt32" -> Some TypeInfo.UInt32
         | "System.UInt64" -> Some TypeInfo.UInt64
         | "System.DateTime" -> Some TypeInfo.DateTime
+        | "System.DateOnly" -> Some TypeInfo.DateOnly
+        | "System.TimeOnly" -> Some TypeInfo.TimeOnly
         | "System.TimeSpan" -> Some TypeInfo.TimeSpan
         | "System.DateTimeOffset" -> Some TypeInfo.DateTimeOffset
         | "System.Boolean" -> Some  TypeInfo.Bool
@@ -224,6 +226,8 @@ module Converter =
         | TypeInfo.Byte
         | TypeInfo.DateTime
         | TypeInfo.DateTimeOffset
+        | TypeInfo.DateOnly
+        | TypeInfo.TimeOnly
         | TypeInfo.BigInt
         | TypeInfo.Guid
         | TypeInfo.Option _ -> true

--- a/src/TypeInfo.fs
+++ b/src/TypeInfo.fs
@@ -36,6 +36,8 @@ type TypeInfo =
     | SByte
     | DateTime
     | DateTimeOffset
+    | DateOnly
+    | TimeOnly
     | BigInt
     | TimeSpan
     | Guid

--- a/test/NagareyamaTests.fs
+++ b/test/NagareyamaTests.fs
@@ -2181,7 +2181,7 @@ let everyTest =
         |> fun result -> test.areEqual result.value DateOnly.MaxValue
 
     testCase "TimeOnly roundtrip" <| fun _ ->
-        let expected = TimeOnly.FromDateTime DateTime.Now
+        let expected = TimeOnly (23, 11, 20, 333)
 
         expected
         |> Json.serialize

--- a/test/NagareyamaTests.fs
+++ b/test/NagareyamaTests.fs
@@ -2165,13 +2165,33 @@ let everyTest =
         |> fun result -> test.areEqual result input
 
     // Fable 2 cannot compile this, so use a directive
-#if NAGAREYAMA
+#if !NAGAREYAMA
     testCase "DateOnly roundtrip" <| fun _ ->
-        let expected = DateOnly.MinValue
+        let expected = DateOnly.FromDateTime DateTime.Now
 
         expected
         |> Json.serialize
         |> Json.parseAs<DateOnly>
         |> fun result -> test.areEqual result expected
+
+    testCase "Deserializing DateOnly works" <| fun _ ->
+        """ { "value": 3652058 } """
+        |> Json.serialize
+        |> Json.parseAs<{| value: DateOnly |}>
+        |> fun result -> test.areEqual result.value DateOnly.MaxValue
+
+    testCase "TimeOnly roundtrip" <| fun _ ->
+        let expected = TimeOnly.FromDateTime DateTime.Now
+
+        expected
+        |> Json.serialize
+        |> Json.parseAs<TimeOnly>
+        |> fun result -> test.areEqual result expected
+
+    testCase "Deserializing TimeOnly works" <| fun _ ->
+        """ { "value": "863999999999" } """
+        |> Json.serialize
+        |> Json.parseAs<{| value: TimeOnly |}>
+        |> fun result -> test.areEqual result.value TimeOnly.MaxValue
 #endif
 ]

--- a/test/NagareyamaTests.fs
+++ b/test/NagareyamaTests.fs
@@ -2165,7 +2165,7 @@ let everyTest =
         |> fun result -> test.areEqual result input
 
     // Fable 2 cannot compile this, so use a directive
-#if !NAGAREYAMA
+#if NAGAREYAMA
     testCase "DateOnly roundtrip" <| fun _ ->
         let expected = DateOnly.FromDateTime DateTime.Now
 

--- a/test/NagareyamaTests.fs
+++ b/test/NagareyamaTests.fs
@@ -2163,4 +2163,15 @@ let everyTest =
         |> Json.serialize
         |> Json.parseNativeAs<FlagsEnum>
         |> fun result -> test.areEqual result input
+
+    // Fable 2 cannot compile this, so use a directive
+#if NAGAREYAMA
+    testCase "DateOnly roundtrip" <| fun _ ->
+        let expected = DateOnly.MinValue
+
+        expected
+        |> Json.serialize
+        |> Json.parseAs<DateOnly>
+        |> fun result -> test.areEqual result expected
+#endif
 ]

--- a/test/Tests.fsproj
+++ b/test/Tests.fsproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\src\Fable.SimpleJson.fsproj" />


### PR DESCRIPTION
Hey, @Zaid-Ajaj. When trying to run the tests in Fable 3,6, I see

```
\dist\tests\fable_modules\Fable.Parsimmon.4.0.0\Parsimmon.fs.js:1
Error [ERR_REQUIRE_ESM]: Must use import to load ES Module: \dist\tests\fable_modules\fable-library.3.6.0-beta-001\Types.js
    at new NodeError (node:internal/errors:277:15)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1119:13)
    at Object.<anonymous> (\dist\tests\fable_modules\Fable.Parsimmon.4.0.0\Parsimmon.fs.js:1)
```

Any idea how to fix this?