### PR TITLE
implement isBrowser to be CSP compliant

### DIFF
--- a/src/Json.Converter.fs
+++ b/src/Json.Converter.fs
@@ -15,8 +15,7 @@ module Node =
     let bytesFromBase64 (value: string) : byte array = jsNative
 
 module Convert =
-    [<Emit("new Function(\"try {return this===window;}catch(e){ return false;}\")")>]
-    let internal isBrowser : unit -> bool = jsNative
+    let internal isBrowser () : bool = importDefault "./isBrowser.js"
 
     let insideBrowser = isBrowser()
 

--- a/src/isBrowser.js
+++ b/src/isBrowser.js
@@ -1,0 +1,3 @@
+export default function isBrowser() {
+    return typeof window !== "undefined" && typeof window.document !== "undefined";
+}

--- a/test/Tests.fs
+++ b/test/Tests.fs
@@ -2162,6 +2162,15 @@ let fable2xTests =
         |> Json.stringify
         |> Json.parseNativeAs<FlagsEnum>
         |> fun result -> test.areEqual result input
+    
+    testCase "Test IsBrowser" <| fun _ ->
+        Fable.SimpleJson.Convert.isBrowser()
+#if MOCHA
+        |> fun result -> test.isFalse result
+#else
+        |> fun result -> test.isTrue result
+#endif
+
 ]
 
 let tests = testList "All tests" [


### PR DESCRIPTION
The current implementation of isBrowser uses eval which is not CSP compliant.
We moved the implementation into an javascript file and import it. 
We hope this solves the problem but we cannot test it until a new version of the Fable.SimpleJson is released.

We wrote a test which checks if isBrowser is working. The test is successfull when run in browser but, of course, fails if run with mocha in node. @Zaid-Ajaj Is there a possibility to write a test which has different expectations according to environment it runs in?